### PR TITLE
fix: remove @semantic-release/git for protected branch compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   "license": "MIT",
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^13.0.1",
-    "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.2",
     "@semantic-release/npm": "^13.1.3",
     "@semantic-release/release-notes-generator": "^14.1.0",

--- a/release.config.js
+++ b/release.config.js
@@ -19,12 +19,5 @@ export default {
       },
     ],
     '@semantic-release/github',
-    [
-      '@semantic-release/git',
-      {
-        assets: ['package.json'],
-        message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
-      },
-    ],
   ],
 };


### PR DESCRIPTION
## Summary
- Removes @semantic-release/git plugin that was pushing version bumps to main
- Releases will still create GitHub releases with tags and publish to npm
- Avoids fighting protected branch rules - cleaner approach

## Test plan
- [ ] Merge this PR
- [ ] Re-run the failed release workflow
- [ ] Verify npm publish and GitHub release work without errors