### PR TITLE
feat: auto-fetch OpenRouter per-provider files based on model ID

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,13 +111,18 @@ git commit -m "feat!: change price format from per-token to per-million"
 
 **Release process:**
 1. Make changes and commit using conventional commits
-2. Push to `main` branch
-3. GitHub Actions runs tests, then semantic-release:
+2. Create PR to `main` branch
+3. PR is squash-merged → GitHub Actions runs tests, then semantic-release:
    - Analyzes commits since last release
    - Determines version bump
    - Updates package.json version
    - Publishes to npm with provenance
    - Creates GitHub release with changelog
+
+> **CRITICAL: PR titles MUST follow conventional commit format.** When PRs are squash-merged, GitHub uses the PR title as the commit message. If the title doesn't follow conventional commits (e.g., `feat: add feature`), semantic-release won't detect the change and no release will be triggered.
+>
+> **Good:** `feat: add OpenRouter per-provider file support`
+> **Bad:** `Add OpenRouter per-provider file support`
 
 **Manual release (if needed):**
 ```bash


### PR DESCRIPTION
## Summary

This PR triggers a release that includes changes from PR #10 which failed to release due to incorrect PR title formatting.

### Features included in this release

**OpenRouter auto-subprovider fetching (from PR #10)**
- When calling `getModelPricing('openrouter', 'anthropic/claude-3.5-sonnet')`, the client now automatically extracts the sub-provider from the model ID and fetches from the smaller per-provider file (`openrouter/anthropic.json`) instead of the deprecated monolithic `openrouter.json`
- Reduces payload size from ~27KB to 1-8KB per request
- Each sub-provider is cached independently
- Fully backward compatible - no API changes required

**Documentation updates**
- Added critical warning to AGENTS.md about PR titles requiring conventional commit format
- Updated README with OpenRouter per-provider endpoint documentation
- Added OpenRouter usage example showing provider/model format

## Why this PR exists

PR #10 was squash-merged with an incorrectly formatted title (missing `feat:` prefix), so semantic-release didn't detect the changes and no npm release was triggered. This PR adds documentation about the PR naming requirement and will trigger the release.